### PR TITLE
add limit for codgen

### DIFF
--- a/internal/generator/typescript/generator.go
+++ b/internal/generator/typescript/generator.go
@@ -116,6 +116,7 @@ const functionTemplate = `{{- range $index, $func := .Functions}}
         arg({{.Name}}, {{getFCLType .TypeStr}}),
         {{- end}}
       ],
+	  	limit: 9999,
     };
     config = await this.runRequestInterceptors(config);
     let result = await fcl.query(config);
@@ -131,6 +132,7 @@ const functionTemplate = `{{- range $index, $func := .Functions}}
         arg({{.Name}}, {{getFCLType .TypeStr}}),
         {{- end}}
       ],
+	  	limit: 9999,
     };
     config = await this.runRequestInterceptors(config);
     let txId = await fcl.mutate(config);

--- a/internal/generator/typescript/generator.go
+++ b/internal/generator/typescript/generator.go
@@ -132,7 +132,7 @@ const functionTemplate = `{{- range $index, $func := .Functions}}
         arg({{.Name}}, {{getFCLType .TypeStr}}),
         {{- end}}
       ],
-	  	limit: 9999,
+	  limit: 9999,
     };
     config = await this.runRequestInterceptors(config);
     let txId = await fcl.mutate(config);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased the default request limit for generated TypeScript query and transaction functions, enabling retrieval of larger data sets in a single call.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->